### PR TITLE
fix compatibility with flysystem updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=5.4.0",
     "league/flysystem": "~1.0",
-    "php-vfs/php-vfs": "~1.2"
+    "php-vfs/php-vfs": "^1.3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5"

--- a/src/VfsAdapter.php
+++ b/src/VfsAdapter.php
@@ -18,6 +18,8 @@ class VfsAdapter extends Local
      */
     public function __construct(FileSystem $vfs)
     {
+        $this->permissionMap = static::$permissions;
+
         $this->vfs = $vfs;
     }
 


### PR DESCRIPTION
thephpleague/flysystem@a8ef1ae37 introduced permissions that are initialized in the parent constructor, so a regression was introduced in the vfs adapter.

also thephpleague/flysystem@9b36795 is causing tests to fail: the problem is caused by the newly introduced iterator, that for some reason causes the vfs adapter to not correctly close the directory handle.

[edit] fixed the latter upstream by michael-donat/php-vfs#45
