### PR TITLE
Updated php-vfs which had GPL license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=5.4.0",
     "league/flysystem": "^1.0",
-    "php-vfs/php-vfs": "^1.3"
+    "php-vfs/php-vfs": "^1.4.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
This PR updates the PHP-VFS lib which was using a GPL license which was conflicting with the MIT license of the flysystem repository.

With the 1.4.2 update the PHP-VFS is also MIT